### PR TITLE
Small bug fix: `esp32ulp_gen_jump_r` wrong jump mode

### DIFF
--- a/gas/config/tc-esp32ulp.c
+++ b/gas/config/tc-esp32ulp.c
@@ -1082,7 +1082,7 @@ INSTR_T esp32ulp_gen_alu_i(int dst, int src1, Expr_Node* addr, int operation)
 INSTR_T esp32ulp_gen_jump_r(int dst_reg, int cond)
 {
 	//DEBUG_TRACE("dya_pass - esp32ulp_gen_jump_r - dst_reg=%i, cond=%i\n", dst_reg, cond);
-	unsigned int local_op = I_JUMP_RI(dst_reg, 0, cond, 0);
+	unsigned int local_op = I_JUMP_RI(dst_reg, 0, cond, 1);
 	return GEN_OPCODE32_DYA(local_op);
 }
 INSTR_T esp32ulp_gen_jump_i(Expr_Node* addr, int cond)


### PR DESCRIPTION
Due to incorrect parameters of `I_JUMP_RI` macro, in function `esp32ulp_gen_jump_r` instruction `jump rX` was generated incorrectly.


